### PR TITLE
Update doc-gen4 for generating only the part of mathlib used

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,9 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build_project:
@@ -57,8 +59,11 @@ jobs:
           mv build/doc _site/doc
           mv blueprint/web _site/blueprint
 
-      - name: Deploy doc & blueprint
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload doc & blueprint artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.github_token }}
-          publish_dir: _site
+          path: '_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -12,7 +12,7 @@
   {"git":
    {"url": "https://github.com/leanprover/doc-gen4",
     "subDir?": null,
-    "rev": "649e7791fa2e6864bf624aea0c03308598123ec3",
+    "rev": "fa8c9d771aa6a06e25468c92b049fecc3e482b99",
     "opts": {},
     "name": "«doc-gen4»",
     "inputRev?": "main",


### PR DESCRIPTION
This PR:

- updates doc-gen4 for generating only the part of mathlib used, thanks to [this commit](https://github.com/leanprover/doc-gen4/commit/fa8c9d771aa6a06e25468c92b049fecc3e482b99)
- fixes Github Pages publish issues due to big declaration index file size

More contexts are [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.204.20project.20blueprint/near/395078326).